### PR TITLE
Add PHP 7.1 and 7.2 to travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 php:
-  - 5.6
-  - 5.5
-  - 5.4
-  - 5.3
+  - 7.1
+  - 7.2
   - hhvm
 install:
   - composer install --prefer-source --no-interaction


### PR DESCRIPTION
I'm not sure what your policy is about supporting EOL PHP versions, but I'd suggest simply not doing so.