### PR TITLE
Add PHP 8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: nightly
+      dist: focal
     - php: hhvm-3.18
   allow_failures:
     - php: hhvm-3.18


### PR DESCRIPTION
This adds PHP nightly build (currently PHP 8), similarly as https://github.com/graphp/graph/pull/199 .

However, as this repository has compatibility declared with `"php": ">=5.3"`, I think the nightly build should be kept here even after PHP 8 image is available on Travis.