### PR TITLE
Improve assertions and testing class name

### DIFF
--- a/tests/FlowTest.php
+++ b/tests/FlowTest.php
@@ -5,7 +5,7 @@ namespace Graphp\Tests\Algorithms;
 use Graphp\Algorithms\Flow as AlgorithmFlow;
 use Graphp\Graph\Graph;
 
-class FlowaTest extends TestCase
+class FlowTest extends TestCase
 {
     public function testGraphEmpty()
     {

--- a/tests/Property/WalkPropertyTest.php
+++ b/tests/Property/WalkPropertyTest.php
@@ -16,8 +16,8 @@ class WalkPropertyTest extends TestCase
 
         $walk = Walk::factoryFromEdges(array(), $v1);
 
-        $this->assertEquals(1, \count($walk->getVertices()));
-        $this->assertEquals(0, \count($walk->getEdges()));
+        $this->assertCount(1, $walk->getVertices());
+        $this->assertCount(0, $walk->getEdges());
 
         $alg = new WalkProperty($walk);
 
@@ -69,8 +69,8 @@ class WalkPropertyTest extends TestCase
 
         $walk = Walk::factoryFromEdges(array($e1, $e2), $v1);
 
-        $this->assertEquals(3, \count($walk->getVertices()));
-        $this->assertEquals(2, \count($walk->getEdges()));
+        $this->assertCount(3, $walk->getVertices());
+        $this->assertCount(2, $walk->getEdges());
 
         $alg = new WalkProperty($walk);
 
@@ -172,8 +172,8 @@ class WalkPropertyTest extends TestCase
         // only use "2 -- 2" part
         $walk = Walk::factoryFromEdges(array($e2), $v2);
 
-        $this->assertEquals(2, \count($walk->getVertices()));
-        $this->assertEquals(1, \count($walk->getEdges()));
+        $this->assertCount(2, $walk->getVertices());
+        $this->assertCount(1, $walk->getEdges());
 
         $alg = new WalkProperty($walk);
 

--- a/tests/Search/BreadthFirstTest.php
+++ b/tests/Search/BreadthFirstTest.php
@@ -6,7 +6,7 @@ use Graphp\Algorithms\Search\BreadthFirst;
 use Graphp\Graph\Graph;
 use Graphp\Tests\Algorithms\TestCase;
 
-class BreadthFirstSearchTest extends TestCase
+class BreadthFirstTest extends TestCase
 {
     public function providerMaxDepth()
     {

--- a/tests/ShortestPath/BaseShortestPathTest.php
+++ b/tests/ShortestPath/BaseShortestPathTest.php
@@ -82,7 +82,7 @@ abstract class BaseShortestPathTest extends TestCase
         $this->assertEquals($expectedWeight, $alg->getDistance($v1));
 
         $walk = $alg->getWalkTo($v1);
-        $this->assertEquals(2, \count($walk->getEdges()));
+        $this->assertCount(2, $walk->getEdges());
     }
 
     public function testIsolatedVertexIsNotReachable()


### PR DESCRIPTION
# Changed log

- Using the `assertCount` to assert expected count is same as result.
- Modify some class name to let them be same as file name.